### PR TITLE
Port scanner examples

### DIFF
--- a/examples/port_scanner/port_scanner.py
+++ b/examples/port_scanner/port_scanner.py
@@ -1,0 +1,35 @@
+import os
+import asyncio
+
+class PortScanner:
+    def __init__(self, host="0.0.0.0", ports=range(1, 1024+1)):
+        self.host       = host
+        self.ports      = ports
+        self.open_files = 0
+        self.file_limit = int(os.popen("ulimit -n").read())
+        self.loop       = asyncio.get_event_loop()
+
+    async def scan_port(self, port, timeout=0.5):
+        try:
+            if self.open_files >= self.file_limit:
+                raise OSError
+            fut = asyncio.open_connection(self.host, port, loop=self.loop)
+            self.open_files += 1
+            await asyncio.wait_for(fut, timeout=0.5)
+            print("{} open".format(port))
+        except (asyncio.TimeoutError, ConnectionRefusedError):
+            print("{} closed".format(port))
+            self.open_files -= 1
+        except OSError:
+            asyncio.sleep(timeout)
+            asyncio.gather(self.scan_port(port, timeout))
+
+    def start(self, timeout=0.5):
+        self.loop.run_until_complete(asyncio.gather(
+            *[self.scan_port(port, timeout) for port in self.ports]
+            ))
+
+
+scanner = PortScanner(ports=range(1, 1024+1))
+
+scanner.start()

--- a/examples/port_scanner/port_scanner.rb
+++ b/examples/port_scanner/port_scanner.rb
@@ -1,0 +1,40 @@
+require 'async/io'
+require 'async/await'
+require 'async/semaphore'
+
+class PortScanner
+  include Async::Await
+  include Async::IO
+
+  def initialize(host: '0.0.0.0', ports:)
+    @host      = host
+    @ports     = ports
+    @semaphore = Async::Semaphore.new(`ulimit -n`.to_i)
+  end
+
+  def scan_port(port, timeout: 0.5)
+    timeout(timeout) do 
+      Async::IO::Endpoint.tcp(@host, port).connect do |peer|
+        peer.close 
+        puts "#{port} open"
+      end
+    end
+  rescue Errno::ECONNREFUSED, Async::TimeoutError
+    puts "#{port} closed"
+  rescue Errno::EMFILE
+    sleep timeout
+    retry 
+  end
+
+  async def start(timeout: 0.5)
+    @ports.map do |port|
+      @semaphore.async do
+        scan_port(port, timeout: timeout)
+      end
+    end.collect(&:result)
+  end
+end
+
+scanner = PortScanner.new(ports: (1..1024))
+
+scanner.start


### PR DESCRIPTION
This PR adds two port scanning examples: one using this project's `async` implementation, and the other for comparison, using python 3.6's `asyncio` implementation. These examples originally lived both [here](https://gist.github.com/picatz/e8a6f526ce236481837f3cdbb9b84152) and [here](https://gist.github.com/picatz/e384ad7cb8a1de9c286fb63e3e552489).

**Note:** The Python example needs to be updated to include [`asyncio.semaphore`](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Semaphore)