### PR TITLE
add golang port scanning example

### DIFF
--- a/examples/port_scanner/port_scanner.go
+++ b/examples/port_scanner/port_scanner.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/sync/semaphore"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// The star of the show, of modest means,
+// used to manage the port scan for a single host.
+type PortScanner struct {
+	ip   string
+	lock *semaphore.Weighted
+}
+
+// Provides a simple wrapper to initializing a PortScanner.
+func NewPortScanner(ip string, limit int64) *PortScanner {
+	return &PortScanner{
+		ip:   "127.0.0.1",
+		lock: semaphore.NewWeighted(limit),
+	}
+}
+
+// Returns the output from the ulimit builtin shell command for the
+// maximum number of open connections, used to limit the number
+// of concurrent port scans.
+func Ulimit() int64 {
+	out, err := exec.Command("ulimit", "-n").Output()
+	if err != nil {
+		panic(err)
+	}
+	s := strings.TrimSpace(string(out))
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// As the name might suggest, this function checks if a given port
+// is open to TCP communication. Used in conjunction with the Start function
+// to sweep over a range of ports concurrently.
+func checkPortOpen(ip string, port int, timeout time.Duration) {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, port), timeout)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "socket") {
+			time.Sleep(500 * time.Millisecond)
+			checkPortOpen(ip, port, timeout)
+		} else {
+			fmt.Println(port, "closed")
+		}
+		return
+	}
+
+	conn.Close()
+
+	fmt.Println(port, "open")
+}
+
+// This function is the bread and butter of this script. It manages the
+// port scanning for a given range of ports with the given timeout value
+// to deal with filtered ports by a firewall typically.
+func (ps *PortScanner) Start(start, stop int, timeout time.Duration) {
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
+
+	for port := start; port <= stop; port++ {
+
+		ctx := context.TODO()
+
+		for {
+			err := ps.lock.Acquire(ctx, 1)
+			if err == nil {
+				break
+			}
+			fmt.Println("nope")
+		}
+
+		wg.Add(1)
+
+		go func(ip string, port int) {
+			defer ps.lock.Release(1)
+			defer wg.Done()
+
+			checkPortOpen(ps.ip, port, timeout)
+		}(ps.ip, port)
+
+	}
+}
+
+// This function kicks off the whole shindig' and provides a
+// basic example of the internal API usage.
+func main() {
+	// Create a new PortScanner for localhost.
+	ps := NewPortScanner("127.0.0.1", Ulimit())
+
+	// Start scanning all the ports on localhost.
+	ps.Start(1, 65535, 500*time.Millisecond)
+}


### PR DESCRIPTION
Another example to live alongside the ruby and python versions.

This example attempts to follow the same style as the [Ruby version](https://github.com/socketry/async-await/blob/master/examples/port_scanner/port_scanner.rb
) I submitted.

## Performance Notes
This example scans 65535 ports in roughly 30 seconds ( roughly 2000 ports a second ):
```
$ go build port_scanner.go
$ time ./port_scanner
...
real	0m31.384s
user	0m4.766s
sys	0m7.653s
```
Please note the golang version is multi-threaded thanks to the golang runtime, while the Ruby/Python versions aren't multiplexed onto multiple threads on blocking I/O, instead the execution is delayed in the event loop.

From what I can tell, it simply takes time for the Python/Ruby versions to iterate through the loop when there's such a large range of ports. This is much nicer than the multi-threaded context switching, but, as seen with Falcon, multi-process seems to be become more important for squeezing out more performance in those runtimes which is pretty different from go's (usually very special) circumstances. I still find the Ruby code a bit easier to reason about honestly, though every example so far has had it's own pros and cons which are nice to see side-by-side.

Perhaps a [Crystal](https://crystal-lang.org/) version could be next. And, I still need to fix the Python one to include the semaphore. 😹 