### PR TITLE
Better error handling in `async_map`.

### DIFF
--- a/lib/async/await/enumerable.rb
+++ b/lib/async/await/enumerable.rb
@@ -13,7 +13,7 @@ module Async
 					parent ||= task
 					
 					self.map do |*arguments|
-						parent.async do
+						parent.async(finished: false) do
 							yield(*arguments)
 						end
 					end.map(&:wait)

--- a/test/async/await/enumerable.rb
+++ b/test/async/await/enumerable.rb
@@ -14,6 +14,14 @@ describe Async::Await::Enumerable do
 			
 			expect(result).to be == [2, 4, 6]
 		end
+		
+		it "should fail if the block fails" do
+			expect do
+				[1, 2, 3].async_map do |value|
+					raise "Fake error!"
+				end
+			end.to raise_exception(RuntimeError, message: be == "Fake error!")
+		end
 	end
 	
 	with '#async_each' do


### PR DESCRIPTION
If an error happens during `async_map`, raise it without logging it (Task may have finished with unhandled exception...).

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
